### PR TITLE
🔧 Do not Render Base64 For Home Here & Subscribe

### DIFF
--- a/src/__hooks__/useQuerySiteConfig.ts
+++ b/src/__hooks__/useQuerySiteConfig.ts
@@ -93,7 +93,7 @@ export const useQuerySiteConfig = (): SiteConfig => {
                     subscribe_copy
                     subscribe_image {
                         fluid(imgixParams: { sat: -100 }) {
-                            ...GatsbyPrismicImageFluid
+                            ...GatsbyPrismicImageFluid_noBase64
                         }
                     }
                 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -65,7 +65,7 @@ export const query = graphql`
                 hero_copy
                 hero_image {
                     fluid(imgixParams: { sat: -100 }) {
-                        ...GatsbyPrismicImageFluid
+                        ...GatsbyPrismicImageFluid_noBase64
                     }
                 }
                 rebrand_link_text


### PR DESCRIPTION
They are really background elements and there is no need for the Base64 overhead here.