### PR TITLE
🔧 fix/resolve-safari-border-radius

### DIFF
--- a/packages/web/src/domains/blog/components/AuthorCard/AuthorCard.styles.ts
+++ b/packages/web/src/domains/blog/components/AuthorCard/AuthorCard.styles.ts
@@ -18,15 +18,18 @@ export const AuthorCard = styled.div`
     }
 
     .avatar {
-        border-radius: 50%;
         line-height: 0;
-        overflow: hidden;
         margin-bottom: ${spacing.component.s};
 
         ${componentBreakpoint} {
             margin-bottom: 0;
             margin-right: ${spacing.component.l};
         }
+    }
+
+    .avatar img {
+        border-radius: 50%;
+        overflow: hidden;
     }
 
     .byline {

--- a/packages/web/src/domains/blog/components/AuthorCard/AuthorCard.styles.ts
+++ b/packages/web/src/domains/blog/components/AuthorCard/AuthorCard.styles.ts
@@ -29,7 +29,6 @@ export const AuthorCard = styled.div`
 
     .avatar img {
         border-radius: 50%;
-        overflow: hidden;
     }
 
     .byline {

--- a/packages/web/src/domains/blog/template/PostTemplate.styles.ts
+++ b/packages/web/src/domains/blog/template/PostTemplate.styles.ts
@@ -7,29 +7,6 @@ import {
     spacing,
 } from '@nerve/core/tokens';
 
-export const BlogHero = styled.div`
-    padding-top: ${spacing.layout.m};
-    padding-bottom: ${spacing.layout.s};
-
-    ${appNavBreakpoint} {
-        padding-bottom: ${spacing.layout.m};
-        padding-top: ${spacing.layout.xl};
-    }
-
-    .title {
-        margin-bottom: ${spacing.component.m};
-    }
-
-    .featured-image {
-        border-radius: ${borders.imageRadius};
-        margin-top: ${spacing.layout.m};
-
-        ${appNavBreakpoint} {
-            margin-top: ${spacing.layout.l};
-        }
-    }
-`;
-
 export const Content = styled.div`
     padding-bottom: ${spacing.layout.m};
 
@@ -102,5 +79,31 @@ export const Content = styled.div`
     /* Any heading tags that are followed immediately by a standard paragraph */
     > :is(div, .h2, .h3, .h4, .h5, .h6) + .p {
         margin-top: 0;
+    }
+`;
+
+export const BlogHero = styled.div`
+    padding-top: ${spacing.layout.m};
+    padding-bottom: ${spacing.layout.s};
+
+    ${appNavBreakpoint} {
+        padding-bottom: ${spacing.layout.m};
+        padding-top: ${spacing.layout.xl};
+    }
+
+    .title {
+        margin-bottom: ${spacing.component.m};
+    }
+
+    .featured-image {
+        margin-top: ${spacing.layout.m};
+
+        ${appNavBreakpoint} {
+            margin-top: ${spacing.layout.l};
+        }
+    }
+
+    .featured-image img {
+        border-radius: ${borders.imageRadius};
     }
 `;

--- a/packages/web/src/domains/show/components/ShowPoster/__styles.ts
+++ b/packages/web/src/domains/show/components/ShowPoster/__styles.ts
@@ -1,21 +1,19 @@
 import styled, { css } from 'styled-components';
 
-import { animation, breakpoints, spacing, zIndex } from '@nerve/core/tokens';
-
-const posterBorderStyles = css`
-    border-radius: 7px;
-    overflow: hidden;
-`;
+import {
+    animation,
+    borders,
+    breakpoints,
+    spacing,
+    zIndex,
+} from '@nerve/core/tokens';
 
 export const ShowPoster = styled.article`
-    ${posterBorderStyles}
     position: relative;
     transition: ${animation.cardHover};
 
     .image {
-        ${posterBorderStyles}
-        border-radius: 7px;
-        overflow: hidden;
+        border-radius: ${borders.imageRadius};
         filter: grayscale(1);
         transition: ${animation.cardHover};
         z-index: ${zIndex.behind};


### PR DESCRIPTION
- Move border radius references to the image element itself. Previously it was applied to the image wrapper and this caused the border radius to not be applied on iOS and Safari.